### PR TITLE
Distance Bellow Widget Calc Fix

### DIFF
--- a/lib/keyboard_actions.dart
+++ b/lib/keyboard_actions.dart
@@ -151,17 +151,26 @@ class KeyboardActionstate extends State<KeyboardActions>
   ///
   /// Used to correctly calculate the offset to "avoid" with BottomAreaAvoider.
   double get _distanceBelowWidget {
-    if (_keyParent.currentContext != null) {
-      final widgetRenderBox =
-          _keyParent.currentContext!.findRenderObject() as RenderBox;
+      final widgetRenderBox = _keyParent.currentContext?.findRenderObject() as RenderBox?;
+
+      if(widgetRenderBox == null) return 0;
+
+      final parentScaffold = Scaffold.maybeOf(context);
+      final hasParentScaffold = parentScaffold != null;
+
+      // Check if the parent Scaffold is configured to resize when keyboard appears
+      // If the Scaffold exists, but the user did not specify a value,
+      // default to true replicating what [Scaffold] does by default.
+      final isParentScaffoldResizingToAvoidBottomInset = hasParentScaffold
+          ? parentScaffold.widget.resizeToAvoidBottomInset ?? true
+          : false;
+
       final fullHeight = MediaQuery.sizeOf(context).height;
       final widgetHeight = widgetRenderBox.size.height;
       final widgetTop = widgetRenderBox.localToGlobal(Offset.zero).dy;
       final widgetBottom = widgetTop + widgetHeight;
-      final distanceBelowWidget = fullHeight - widgetBottom;
+      final distanceBelowWidget = isParentScaffoldResizingToAvoidBottomInset ? 0.0 : fullHeight - widgetBottom;
       return distanceBelowWidget;
-    }
-    return 0;
   }
 
   /// Set the config for the keyboard action bar.


### PR DESCRIPTION
The package does not take into account the fact that `Scaffold` can resize the screen (they do it by default), so it is coming up with a `distanceBellowWidget` greater than 0 even when there is nothing bellow the widget.

It will now automatically detect if the screen is being resized and act accordingly.

`resizeToAvoidBottomInset` set to false
https://github.com/user-attachments/assets/b37edc29-be92-444f-b95a-5aece6ffb557

`resizeToAvoidBottomInset` set to true or not set
https://github.com/user-attachments/assets/58f3158f-9392-4199-a6a5-27db4cb21b7d


